### PR TITLE
[Mellanox] Integrate HW-MGMT 7.0040.2207 Changes

### DIFF
--- a/patch/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
+++ b/patch/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
@@ -1,8 +1,7 @@
-From ddec9cfeb44ed194cadee824f3f49c057bf7a560 Mon Sep 17 00:00:00 2001
+From ac10df67c019b8ee1c80b46390759669cd69862f Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 12 Jul 2023 14:26:38 +0000
-Subject: [PATH backport v6.1 30/32] platform: mellanox: nvsw-sn2201: change
- fans i2c busses.
+Subject: [PATCH 2/4] platform: mellanox: nvsw-sn2201: change fans i2c busses.
 
 Link: https://www.spinics.net/lists/platform-driver-x86/msg39647.html
 
@@ -18,7 +17,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 7b9c107c17ce..75b699676ca6 100644
+index f53baf7e7..1a7c45aa4 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -84,6 +84,10 @@

--- a/patch/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
+++ b/patch/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
@@ -1,7 +1,7 @@
-From ab5040e2b99cc3eb57eaa266b90877bcc38c28ed Mon Sep 17 00:00:00 2001
+From 1c43cf584d3fd62823dd3b28018481f15a8836c7 Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 29 Nov 2023 13:12:38 +0000
-Subject: [PATCH v1 1/1] platform: mellanox: indicate deferred I2C bus creation
+Subject: [PATCH 3/4] platform: mellanox: indicate deferred I2C bus creation
  for a hot-plug driver
 
 It fixes timing issue when during initialization hot-plug driver
@@ -15,7 +15,7 @@ Signed-off-by: Michael Shych <michaelsh@nvidia.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 65b677690..79e4d0619 100644
+index 1a7c45aa4..a3e2bc6d6 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -520,6 +520,7 @@ struct mlxreg_core_hotplug_platform_data nvsw_sn2201_hotplug = {
@@ -27,5 +27,5 @@ index 65b677690..79e4d0619 100644
  
  /* SN2201 static devices. */
 -- 
-2.14.1
+2.20.1
 

--- a/patch/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/patch/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -1,8 +1,7 @@
-From 2f247a7eaf25a3de00d6319f2b6314d0c3bf36f6 Mon Sep 17 00:00:00 2001
+From e0e79f6b5bcd0028f2c6e47e5c8eacff514c9443 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Mon, 17 Jun 2024 00:52:00 +0300
-Subject: [PATCH backport v6.1 1/2] platform/mellanox: mlxreg-dpu: Add initial
- support for Nvidia DPU
+Date: Mon, 4 Dec 2023 07:12:52 +0000
+Subject: platform/mellanox: mlxreg-dpu: Add initial support for Nvidia DPU
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -28,12 +27,12 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/platform/mellanox/Kconfig      |  12 +
  drivers/platform/mellanox/Makefile     |   1 +
- drivers/platform/mellanox/mlxreg-dpu.c | 625 +++++++++++++++++++++++++
- 3 files changed, 638 insertions(+)
+ drivers/platform/mellanox/mlxreg-dpu.c | 626 +++++++++++++++++++++++++
+ 3 files changed, 639 insertions(+)
  create mode 100644 drivers/platform/mellanox/mlxreg-dpu.c
 
 diff --git a/drivers/platform/mellanox/Kconfig b/drivers/platform/mellanox/Kconfig
-index 6f9cb3a88d68..750c4c0905d7 100644
+index 018ce2833..14c14c9c2 100644
 --- a/drivers/platform/mellanox/Kconfig
 +++ b/drivers/platform/mellanox/Kconfig
 @@ -26,6 +26,18 @@ config MLX_PLATFORM
@@ -69,18 +68,19 @@ index ba56485cbe8c..e86723b44c2e 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000000..f831d6dd5ece
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
-@@ -0,0 +1,625 @@
+@@ -0,0 +1,626 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia Data Processor Unit platform driver
 + *
-+ * Copyright (C) 2024 Nvidia Technologies Ltd.
++ * Copyright (C) 2025 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>
++#include <linux/dev_printk.h>
 +#include <linux/i2c.h>
 +#include <linux/module.h>
 +#include <linux/platform_data/mlxcpld.h>
@@ -389,13 +389,14 @@ index 000000000000..f831d6dd5ece
 +	.mask = MLXREG_DPU_AGGR_MASK,
 +};
 +
-+/* mlxreg_dpu - device private data
-+ * @dev: platform device;
-+ * @data: pltaform core data;
-+ * @io_data: register access platform data;
-+ * @io_regs: register access device;
-+ * @hotplug_data: hotplug platform data;
-+ * @hotplug: hotplug device;
++/**
++ * struct mlxreg_dpu - device private data
++ * @dev: platform device
++ * @data: platform core data
++ * @io_data: register access platform data
++ * @io_regs: register access device
++ * @hotplug_data: hotplug platform data
++ * @hotplug: hotplug device
 + */
 +struct mlxreg_dpu {
 +	struct device *dev;
@@ -478,6 +479,11 @@ index 000000000000..f831d6dd5ece
 +	return false;
 +}
 +
++static const struct reg_default mlxreg_dpu_regmap_default[] = {
++        { MLXREG_DPU_REG_PG_EVENT_OFFSET, 0x00 },
++        { MLXREG_DPU_REG_HEALTH_EVENT_OFFSET, 0x00 },
++};
++
 +/* Configuration for the register map of a device with 2 bytes address space. */
 +static const struct regmap_config mlxreg_dpu_regmap_conf = {
 +	.reg_bits = 16,
@@ -487,10 +493,13 @@ index 000000000000..f831d6dd5ece
 +	.writeable_reg = mlxreg_dpu_writeable_reg,
 +	.readable_reg = mlxreg_dpu_readable_reg,
 +	.volatile_reg = mlxreg_dpu_volatile_reg,
++	.reg_defaults = mlxreg_dpu_regmap_default,
++	.num_reg_defaults = ARRAY_SIZE(mlxreg_dpu_regmap_default),
 +};
 +
-+static int mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
-+					struct mlxreg_core_hotplug_platform_data *hotplug_data)
++static int
++mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
++			     const struct mlxreg_core_hotplug_platform_data *hotplug_data)
 +{
 +	struct mlxreg_core_item *item;
 +	int i;
@@ -502,18 +511,15 @@ index 000000000000..f831d6dd5ece
 +
 +	mlxreg_dpu->hotplug_data->items = devm_kmemdup(dev, hotplug_data->items,
 +						       mlxreg_dpu->hotplug_data->counter *
-+						       sizeof(*hotplug_data->items),
++						       sizeof(*mlxreg_dpu->hotplug_data->items),
 +						       GFP_KERNEL);
 +	if (!mlxreg_dpu->hotplug_data->items)
 +		return -ENOMEM;
 +
 +	item = mlxreg_dpu->hotplug_data->items;
-+	for (i = 0; i < mlxreg_dpu->hotplug_data->counter; i++, item++) {
-+		item = devm_kmemdup(dev, &hotplug_data->items[i], sizeof(*item), GFP_KERNEL);
-+		if (!item)
-+			return -ENOMEM;
++	for (i = 0; i < hotplug_data->counter; i++, item++) {
 +		item->data = devm_kmemdup(dev, hotplug_data->items[i].data,
-+					  hotplug_data->items[i].count * sizeof(item->data),
++					  hotplug_data->items[i].count * sizeof(*item->data),
 +					  GFP_KERNEL);
 +		if (!item->data)
 +			return -ENOMEM;
@@ -533,6 +539,7 @@ index 000000000000..f831d6dd5ece
 +	err = regmap_read(regmap, MLXREG_DPU_REG_CONFIG3_OFFSET, &regval);
 +	if (err)
 +		return err;
++
 +	switch (regval) {
 +	case MLXREG_DPU_BF3:
 +		/* Copy platform specific hotplug data. */
@@ -552,15 +559,15 @@ index 000000000000..f831d6dd5ece
 +	if (mlxreg_dpu->io_data) {
 +		mlxreg_dpu->io_data->regmap = regmap;
 +		mlxreg_dpu->io_regs =
-+		platform_device_register_resndata(dev, "mlxreg-io", data->slot, NULL, 0,
-+						  mlxreg_dpu->io_data,
-+						  sizeof(*mlxreg_dpu->io_data));
++			platform_device_register_resndata(dev, "mlxreg-io",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->io_data,
++							  sizeof(*mlxreg_dpu->io_data));
 +		if (IS_ERR(mlxreg_dpu->io_regs)) {
 +			dev_err(dev, "Failed to create regio for client %s at bus %d at addr 0x%02x\n",
 +				data->hpdev.brdinfo->type, data->hpdev.nr,
 +				data->hpdev.brdinfo->addr);
-+			err = PTR_ERR(mlxreg_dpu->io_regs);
-+			goto fail_register_io;
++			return PTR_ERR(mlxreg_dpu->io_regs);
 +		}
 +	}
 +
@@ -569,9 +576,10 @@ index 000000000000..f831d6dd5ece
 +		mlxreg_dpu->hotplug_data->regmap = regmap;
 +		mlxreg_dpu->hotplug_data->irq = irq;
 +		mlxreg_dpu->hotplug =
-+		platform_device_register_resndata(dev, "mlxreg-hotplug", data->slot, NULL, 0,
-+						  mlxreg_dpu->hotplug_data,
-+						  sizeof(*mlxreg_dpu->hotplug_data));
++			platform_device_register_resndata(dev, "mlxreg-hotplug",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->hotplug_data,
++							  sizeof(*mlxreg_dpu->hotplug_data));
 +		if (IS_ERR(mlxreg_dpu->hotplug)) {
 +			err = PTR_ERR(mlxreg_dpu->hotplug);
 +			goto fail_register_hotplug;
@@ -582,16 +590,13 @@ index 000000000000..f831d6dd5ece
 +
 +fail_register_hotplug:
 +	platform_device_unregister(mlxreg_dpu->io_regs);
-+fail_register_io:
 +
 +	return err;
 +}
 +
 +static void mlxreg_dpu_config_exit(struct mlxreg_dpu *mlxreg_dpu)
 +{
-+	/* Unregister hotplug driver. */
 +	platform_device_unregister(mlxreg_dpu->hotplug);
-+	/* Unregister IO access driver. */
 +	platform_device_unregister(mlxreg_dpu->io_regs);
 +}
 +
@@ -606,13 +611,13 @@ index 000000000000..f831d6dd5ece
 +	if (!data || !data->hpdev.brdinfo)
 +		return -EINVAL;
 +
-+	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
-+	if (!mlxreg_dpu)
-+		return -ENOMEM;
-+
 +	data->hpdev.adapter = i2c_get_adapter(data->hpdev.nr);
 +	if (!data->hpdev.adapter)
 +		return -EPROBE_DEFER;
++
++	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
++	if (!mlxreg_dpu)
++		return -ENOMEM;
 +
 +	/* Create device at the top of DPU I2C tree.*/
 +	data->hpdev.client = i2c_new_client_device(data->hpdev.adapter,
@@ -624,8 +629,7 @@ index 000000000000..f831d6dd5ece
 +		goto i2c_new_device_fail;
 +	}
 +
-+	regmap = devm_regmap_init_i2c(data->hpdev.client,
-+				      &mlxreg_dpu_regmap_conf);
++	regmap = devm_regmap_init_i2c(data->hpdev.client, &mlxreg_dpu_regmap_conf);
 +	if (IS_ERR(regmap)) {
 +		dev_err(&pdev->dev, "Failed to create regmap for client %s at bus %d at addr 0x%02x\n",
 +			data->hpdev.brdinfo->type, data->hpdev.nr, data->hpdev.brdinfo->addr);
@@ -647,12 +651,9 @@ index 000000000000..f831d6dd5ece
 +	mlxreg_dpu->dev = &pdev->dev;
 +	platform_set_drvdata(pdev, mlxreg_dpu);
 +
-+	/* Configure DPU. */
 +	err = mlxreg_dpu_config_init(mlxreg_dpu, regmap, data, data->hpdev.brdinfo->irq);
 +	if (err)
 +		goto mlxreg_dpu_config_init_fail;
-+
-+	return err;
 +
 +mlxreg_dpu_config_init_fail:
 +regcache_sync_fail:
@@ -697,7 +698,6 @@ index 000000000000..f831d6dd5ece
 +MODULE_DESCRIPTION("Nvidia Data Processor Unit platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:mlxreg-dpu");
-+
 -- 
-2.34.1
+2.44.0
 

--- a/patch/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
+++ b/patch/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
@@ -1,8 +1,8 @@
-From 693ea1c72c6f1b83232c043fdb1b175a450bc172 Mon Sep 17 00:00:00 2001
-From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Wed, 7 Aug 2024 00:09:11 +0000
-Subject: [PATCH backport 6.1 1/1] platform: mellanox: nvsw-sn2200: Add support
- for new system flavour
+From 13e4e0e5b566a116e2107a0a959d2b294b388b42 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 11 Dec 2024 17:49:45 +0200
+Subject: [PATCH 4/4] platform: mellanox: nvsw-sn2200: Add support for new
+ system flavour
 
 Add support for SN2201 system flavour, which is fitting OCP rack
 form-factor and feeded from external power source through the rack
@@ -15,11 +15,11 @@ For new system flavour:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/nvsw-sn2201.c | 111 +++++++++++++++++++++++-
- 1 file changed, 108 insertions(+), 3 deletions(-)
+ drivers/platform/mellanox/nvsw-sn2201.c | 112 +++++++++++++++++++++++-
+ 1 file changed, 109 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 2612bb5f82a3..d604069e3313 100644
+index a3e2bc6d6..64c705f3b 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -6,6 +6,7 @@
@@ -103,7 +103,7 @@ index 2612bb5f82a3..d604069e3313 100644
  };
  
  /* SN2201 default static board info. */
-@@ -608,6 +647,58 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
+@@ -608,6 +647,59 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
  	},
  };
  
@@ -159,10 +159,11 @@ index 2612bb5f82a3..d604069e3313 100644
 +	},
 +};
 +
++
  /* LED default data. */
  static struct mlxreg_core_data nvsw_sn2201_led_data[] = {
  	{
-@@ -982,7 +1073,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
+@@ -982,7 +1074,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
  	nvsw_sn2201->io_data = &nvsw_sn2201_regs_io;
  	nvsw_sn2201->led_data = &nvsw_sn2201_led;
  	nvsw_sn2201->wd_data = &nvsw_sn2201_wd;
@@ -174,11 +175,12 @@ index 2612bb5f82a3..d604069e3313 100644
  
  	/* Register IO access driver. */
  	if (nvsw_sn2201->io_data) {
-@@ -1199,11 +1293,17 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
+@@ -1199,12 +1294,18 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
  static int nvsw_sn2201_probe(struct platform_device *pdev)
  {
  	struct nvsw_sn2201 *nvsw_sn2201;
 +	const char *sku;
+ 	int ret;
  
  	nvsw_sn2201 = devm_kzalloc(&pdev->dev, sizeof(*nvsw_sn2201), GFP_KERNEL);
  	if (!nvsw_sn2201)
@@ -191,8 +193,8 @@ index 2612bb5f82a3..d604069e3313 100644
 +
  	nvsw_sn2201->dev = &pdev->dev;
  	platform_set_drvdata(pdev, nvsw_sn2201);
- 	platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
-@@ -1212,8 +1312,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ 	ret = platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
+@@ -1215,8 +1316,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
  	nvsw_sn2201->main_mux_deferred_nr = NVSW_SN2201_MAIN_MUX_DEFER_NR;
  	nvsw_sn2201->main_mux_devs = nvsw_sn2201_main_mux_brdinfo;
  	nvsw_sn2201->cpld_devs = nvsw_sn2201_cpld_brdinfo;
@@ -209,5 +211,5 @@ index 2612bb5f82a3..d604069e3313 100644
  	return nvsw_sn2201_config_pre_init(nvsw_sn2201);
  }
 -- 
-2.44.0
+2.20.1
 

--- a/patch/0098-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
+++ b/patch/0098-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
@@ -1,0 +1,152 @@
+From a66f017a034d2b370c341af5e0eeb71ba7f44fc9 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Tue, 18 Mar 2025 21:15:00 +0200
+Subject: platform/mellanox: mlxreg-dpu: Introduce completion callback
+
+DPU auxiliary powering can cause interrupt flooding because
+DPU interrupt handlers are not configured yet, while middle
+interrupt aggregation register is unmasked by default during
+initialization. Thus, interrupts are getting through, while
+handlers are still not fully initialized. Do not unmask
+aggregation interrupt register at initialization for all
+DPUs. Instead do it per DPU, when its initialization is done.
+
+This patch also adds the change to clear the DPU event
+registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 28 +++++++++++++++++++++---
+ drivers/platform/mellanox/mlxreg-dpu.c   |  8 +++++++
+ include/linux/platform_data/mlxreg.h     |  4 ++++
+ 3 files changed, 37 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index b2ef122ad..377abea97 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -2131,6 +2131,8 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	},
+ };
+ 
++#define MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(s)   (GENMASK((s) * 2 - 1, (s) * 2 - 2))
++
+ 
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_lc_act = {
+@@ -3267,6 +3269,23 @@ static struct mlxreg_core_item mlxplat_mlxcpld_smart_switch_items[] = {
+ 	},
+ };
+ 
++static int mlxplat_dpu_completion_notify(void *handle, int id)
++{
++       u32 regval, mask;
++       int err;
++
++       if (id <= 0 || id > 4)
++               return -EINVAL;
++
++       err = regmap_read(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, &regval);
++       if (err)
++               return err;
++
++       mask = MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(id);
++
++       return regmap_write(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, regval | mask);
++}
++
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_smart_switch_data = {
+ 	.items = mlxplat_mlxcpld_smart_switch_items,
+@@ -3304,24 +3323,28 @@ static struct mlxreg_core_data mlxplat_mlxcpld_smart_switch_dpu_data[] = {
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[0],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE,
+ 		.slot = 1,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu2",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[1],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 1,
+ 		.slot = 2,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu3",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 2,
+ 		.slot = 3,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu4",
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
++		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[3],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 3,
+ 		.slot = 4,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ };
+ 
+@@ -7606,8 +7629,6 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+-	{ MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET,
+-	  MLXPLAT_CPLD_LPC_SM_SW_MASK },
+ };
+ 
+ struct mlxplat_mlxcpld_regmap_context {
+@@ -8866,6 +8887,7 @@ static int mlxplat_post_init(struct mlxplat_priv *priv)
+ 	/* Add DPU drivers. */
+ 	for (j = 0; j < MLXPLAT_CPLD_DPU_MAX_DEVS; j++) {
+ 		if (mlxplat_dpu_data[j]) {
++			mlxplat_dpu_data[j]->handle = priv->regmap;
+ 			priv->pdev_dpu[j] =
+ 				platform_device_register_resndata(&mlxplat_dev->dev, "mlxreg-dpu",
+ 								  j, NULL, 0, mlxplat_dpu_data[j],
+diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
+index b7685012d..aa8923c49 100644
+--- a/drivers/platform/mellanox/mlxreg-dpu.c
++++ b/drivers/platform/mellanox/mlxreg-dpu.c
+@@ -581,6 +581,14 @@ static int mlxreg_dpu_probe(struct platform_device *pdev)
+ 	if (err)
+ 		goto mlxreg_dpu_config_init_fail;
+ 
++	err = data->completion_notify(data->handle, data->slot);
++	if (err)
++		goto mlxreg_dpu_completion_notify_fail;
++
++	return err;
++
++mlxreg_dpu_completion_notify_fail:
++	mlxreg_dpu_config_exit(mlxreg_dpu);
+ mlxreg_dpu_config_init_fail:
+ regcache_sync_fail:
+ devm_regmap_init_i2c_fail:
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index d9f679752..7d054ddda 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -133,6 +133,8 @@ struct mlxreg_hotplug_device {
+  * @regnum: number of registers occupied by multi-register attribute;
+  * @slot: slot number, at which device is located;
+  * @secured: if set indicates that entry access is secured;
++ + @handle: parent handle;
++ + @completion_notify: callback to notify when platform driver probing is done;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+@@ -155,6 +157,8 @@ struct mlxreg_core_data {
+ 	u8 regnum;
+ 	u8 slot;
+ 	u8 secured;
++	void *handle;
++	int (*completion_notify)(void *handle, int id);
+ };
+ 
+ /**
+-- 
+2.44.0
+

--- a/patch/series
+++ b/patch/series
@@ -139,7 +139,7 @@ Support-for-fullcone-nat.patch
 0092-platform-mellanox-Introduce-support-of-Nvidia-smart-.patch
 0093-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2855-c.patch
 0094-i2c-asf-Introduce-MCTP-support-over-ASF-controller.patch
-#0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
+0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
 0097-platform-mellanox-mlx-platform-Add-support-for-new-N.patch
 8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch
 8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch
@@ -151,6 +151,7 @@ Support-for-fullcone-nat.patch
 8009-hwmon-mlxsw-Downstream-Allow-fan-speed-setting-granu.patch
 8010-mlxsw-i2c-Downstream-Add-retry-mechanism-for-failed-.patch
 8011-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch
+0098-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
 ###-> mellanox_hw_mgmt-end
 
 # Cisco patches for 5.10 kernel


### PR DESCRIPTION
Integrate HW-MGMT 7.0040.2207 to support Kernel 6.1.1.23 upgrade

 ## Patch List
* 0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch :
* 0098-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch :