### PR TITLE
disabled CONFIG_IO_STRICT_DEVMEM

### DIFF
--- a/config.local/featureset-sonic/config
+++ b/config.local/featureset-sonic/config
@@ -15,3 +15,5 @@ CONFIG_MEDIA_ATTACH=n
 
 # Disable module compression, since squashfs will do compression anyways
 CONFIG_MODULE_COMPRESS=n
+# Disable strict /dev/mem access checks to allow mmap on PCI resource file
+CONFIG_IO_STRICT_DEVMEM=n


### PR DESCRIPTION
disabled CONFIG_IO_STRICT_DEVMEM as mmap was not working on pci resource file. will keep it disabled until we find alternate way to access pci resource file.