### PR TITLE
create new file for mellanox-arm64 config in Debian 13

### DIFF
--- a/config.local/arm64/config.sonic-mellanox
+++ b/config.local/arm64/config.sonic-mellanox
@@ -1,0 +1,2 @@
+[mellanox-arm64]
+


### PR DESCRIPTION
create new file for mellanox-arm64 config in Debian 13

This is required for compatibility with changes made to patches and config in slk in Trixie.