### PR TITLE
arm64-dts/marvell: cn9131-db-comexpress with regulator-fixed

### DIFF
--- a/patches-sonic/0022-arm64-dts-marvell-Add-DTS-for-cn9131-db-comexpress-trixie.patch
+++ b/patches-sonic/0022-arm64-dts-marvell-Add-DTS-for-cn9131-db-comexpress-trixie.patch
@@ -71,7 +71,7 @@ index 000000000..d738a214d
 +		 *  gpios = <&expander0 8 GPIO_ACTIVE_HIGH>;
 +		 *  expander0: pca9555@21 { compatible = "nxp,pca9555";
 +		 */
-+		compatible = "regulator-gpio";
++		compatible = "regulator-fixed"; /* regulator-gpio not on board */
 +		regulator-name = "ap0_sd_vccq";
 +		regulator-min-microvolt = <1800000>;
 +		regulator-max-microvolt = <1800000>;


### PR DESCRIPTION
The legacy cn9131-db-comexpress.dts configures "regulator-gpio".
This legacy regulator is defined min/max=1.8V and works on Kernel-6.1 just
because the power 1.8V already set.
In fact, the regulator is Not present on board, the TRXIES Kernel-6.12
gpio probe waits for regulator, never passes and MMC/SDHCI is never activated.
    
FIX:
Declare "regulator-fixed" instead of "regulator-gpio".
